### PR TITLE
adds fastboot compatibility

### DIFF
--- a/addon/components/quill-editor.js
+++ b/addon/components/quill-editor.js
@@ -1,20 +1,25 @@
 /* global Quill */
 
-import Ember from "ember";
-import layout from "../templates/components/quill-editor";
+import Ember from 'ember';
+import layout from '../templates/components/quill-editor';
 
-const { Component, computed, get, set } = Ember;
+const {Component, computed, get, set, getOwner} = Ember;
 
 export default Component.extend({
   layout,
   editor: null,
 
   options: computed(function() {
-    return {theme: "snow"};
+    return {theme: 'snow'};
   }),
 
   safeValue: computed(function() {
-    return Ember.String.htmlSafe(get(this, "value"));
+    return Ember.String.htmlSafe(get(this, 'value'));
+  }),
+
+  fastboot: computed(function() {
+    let owner = getOwner(this);
+    return owner.lookup('service:fastboot');
   }),
 
   // didUpdateAttrs() {
@@ -23,17 +28,34 @@ export default Component.extend({
   // }
 
   didInsertElement() {
-    const self = this;
-    const html = this.$().get(0);
-    const editor = new Quill(this.$().get(0), get(this, "options"));
+    // don't instantiate Quill if fastboot is detected
+    const isFastBoot = this.get('fastboot.isFastBoot');
 
-    editor.on("text-change", (delta, oldDelta, source) => {
-      self.sendAction("textChange", get(self, "editor"), delta, oldDelta, source);
-    });
-    editor.on("selection-change", (delta, oldDelta, source) => {
-      self.sendAction("selectionChange", get(self, "editor"), delta, oldDelta, source);
-    });
+    if (!isFastBoot) {
+      const self = this;
+      const html = this.$().get(0);
+      const editor = new Quill(this.$().get(0), get(this, 'options'));
 
-    set(this, "editor", editor);
-  }
+      editor.on('text-change', (delta, oldDelta, source) => {
+        self.sendAction(
+          'textChange',
+          get(self, 'editor'),
+          delta,
+          oldDelta,
+          source
+        );
+      });
+      editor.on('selection-change', (delta, oldDelta, source) => {
+        self.sendAction(
+          'selectionChange',
+          get(self, 'editor'),
+          delta,
+          oldDelta,
+          source
+        );
+      });
+
+      set(this, 'editor', editor);
+    }
+  },
 });

--- a/index.js
+++ b/index.js
@@ -1,20 +1,26 @@
 /* jshint node: true */
-"use strict";
+'use strict';
 
 module.exports = {
-  name: "ember-quill",
+  name: 'ember-quill',
   options: {
     nodeAssets: {
-      quill: {
-        import: [
-          "dist/quill.min.js",
-          "dist/quill.min.js.map",
-          "dist/quill.snow.css"
-        ]
-      }
-    }
+      quill: function() {
+        if (!process.env.EMBER_CLI_FASTBOOT) {
+          return {
+            import: [
+              'dist/quill.min.js',
+              'dist/quill.min.js.map',
+              'dist/quill.snow.css',
+            ],
+          };
+        } else {
+          return {};
+        }
+      },
+    },
   },
   isDevelopingAddon: function() {
     return true;
-  }
+  },
 };


### PR DESCRIPTION
The changes will make this addon [fastboot](https://ember-fastboot.com/) compatible by basically doing 2 things:

* exclude Quill from fastboot builds (causing errors in fastboot)
* don't try to instantiate Quill if Ember app is in fastboot mode

@jgelens please review